### PR TITLE
Added information when running MPL in Container and MC-Server locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ An example docker run command looks like this:
 docker run \
   --detach \
   --publish 8888:8888 \
+  --add-host=host.docker.internal:host-gateway
   --name minecraft-player-locations \
   --env "NODE_ENV=production" \
   --env "RCON_HOST=MyMineCraftHost" \
@@ -83,8 +84,6 @@ docker run \
 **--env "RCON_PORT=25575"** - This is the port RCON is listening to as defined in Minecraft's server.properties file
 
 **--env "RCON_PASSWORD=supersecretpassword"** - This is the password to connect to RCON as defined in Minecraft's server.properties file
-
-**--add-host=host.docker.internal:host-gateway"** - This env has to be added when running a Docker Version below 18.03.
 
 #### HTTPS Configuration
 Additional configuration required for maps running over https.

--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ docker run \
 
 **--publish 8888:8888** - This is what maps the container port to the host port. If you need a different port bound to the local machine, change the right hand port number
 
-**--env "RCON_HOST=MyMineCraftHost"** - This is the hostname of the Minecraft server
+**--env "RCON_HOST=MyMineCraftHost"** - This is the hostname of the Minecraft server. When hosting the minecraft directly on your machine this value has to be set to `host.docker.internal`.
 
 **--env "RCON_PORT=25575"** - This is the port RCON is listening to as defined in Minecraft's server.properties file
 
 **--env "RCON_PASSWORD=supersecretpassword"** - This is the password to connect to RCON as defined in Minecraft's server.properties file
+
+**--add-host=host.docker.internal:host-gateway"** - This env has to be added when running a Docker Version below 18.03.
 
 #### HTTPS Configuration
 Additional configuration required for maps running over https.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ docker run \
 
 **--publish 8888:8888** - This is what maps the container port to the host port. If you need a different port bound to the local machine, change the right hand port number
 
-**--env "RCON_HOST=MyMineCraftHost"** - This is the hostname of the Minecraft server. When hosting the minecraft directly on your machine this value has to be set to `host.docker.internal`.
+**--env "RCON_HOST=MyMineCraftHost"** - This is the hostname of the Minecraft server. When hosting the minecraft server directly on your machine this value has to be set to `host.docker.internal`.
 
 **--env "RCON_PORT=25575"** - This is the port RCON is listening to as defined in Minecraft's server.properties file
 


### PR DESCRIPTION
The `--add-host=host.docker.internal:host-gateway` has to be set when using a Docker-Version below 18.03 and hosting the MC-Server on the docker-host itself via official server files. When running a server inside a container this env can be ignored, but it also does not limit the functionality.

The value `host.docker.internal` can be set even if the Docker version is [18.03+ without issues.](https://docs.docker.com/network/host/) 

This edit is just for clarification if someone is fairly new to using docker.